### PR TITLE
Remove sign up sheet from public website

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     <div class="sechighlight">
         <div class="container sec" id="logistics">
             <div class="alert alert-danger" role="alert">
-                <a href="https://piazza.com/class/kj25zdvr9nt5ax?cid=58">Project instructions</a> (<a href="https://piazza.com/class/kj25zdvr9nt5ax?cid=82">project mentor signup sheet</a>) are out! Lecture notes 3 & 4 will be released end of week.
+                <a href="https://piazza.com/class/kj25zdvr9nt5ax?cid=58">Project instructions</a> are out! Lecture notes 3 & 4 will be released end of week.
             </div>
             <h2>Logistics</h2>
             <ul>


### PR DESCRIPTION
Maybe be good to hide the link since it has student emails. Or you could make the sign up sheet viewable only in Stanford network.